### PR TITLE
Fixed most common issues related to the dropdown behaviour and caching in the local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
-# Light/Dark/Solar Mode Theme Toggler
+# Light 🏙 - Dark 🌌 - Solar 🌇 Mode Theme Toggler
 
-[Dynamic theme-toggler tutorial](https://youtu.be/rXuHGLzSmSE) with CSS Variables and JavaScript.  
+In this version of css theme toggler app I've resolved these problems: 
 
-
-All see [CSS Variables in 100 Seconds](https://youtu.be/NtRmIp4eMjs). 
+* Initial ```light``` class is now being added to the body **programmatically**. In the _Fireship's_ version after page reload you could notice that body deriving preffered theme from the local storage and adding it to the already exsisiting one which is **hardcoded** light theme (so, if preferred theme was **dark** then after the page reload you will see ```<body class="light dark">```.
+* In initial version of this app if you choose **solarized** theme — ```solarizeButton``` acquires _normalize_ ```innerText``` property. But when page is reloaded it **loses** its value although the theme is still **solarized**. Now it will keep it.
+* Dropdown was accessible via page inspector and **dev tools** even when it was hidden. I've changed its ```z-index``` property so now it is truly **unreachable** when hidden.
+* Removed unnecessary ```pointer-events: auto;``` property because its **implicitly** has necessary value.

--- a/public/app.js
+++ b/public/app.js
@@ -14,6 +14,10 @@ const isSolar = localStorage.getItem('isSolar');
 if (theme) {
   body.classList.add(theme);
   isSolar && body.classList.add('solar');
+  if (isSolar) {
+    solarButton.innerText = "normalize";
+    solarButton.style.cssText = `--bg-solar: white;`;
+  }
 } else {
     body.classList.add('light');
     localStorage.setItem('theme', 'light');

--- a/public/app.js
+++ b/public/app.js
@@ -14,6 +14,9 @@ const isSolar = localStorage.getItem('isSolar');
 if (theme) {
   body.classList.add(theme);
   isSolar && body.classList.add('solar');
+} else {
+    body.classList.add('light');
+    localStorage.setItem('theme', 'light');
 }
 
 // Button Event Handlers

--- a/public/index.html
+++ b/public/index.html
@@ -15,7 +15,7 @@
     <script defer src="app.js"></script>
   </head>
 
-  <body class="light">
+  <body>
     <!-- Navbar -->
 
     <nav class="navbar">

--- a/public/style.css
+++ b/public/style.css
@@ -83,7 +83,6 @@ img {
 .has-dropdown:focus-within .dropdown   {
     opacity: 1;
     z-index: 1;
-    pointer-events: auto;
 }
 
 

--- a/public/style.css
+++ b/public/style.css
@@ -59,7 +59,7 @@ img {
     position: absolute;
     width: 500px;
     opacity: 0;
-    z-index: 2;
+    z-index: -1;
     background: var(--bg-dropdown);
     border-top: 2px solid var(--border-color);
 
@@ -82,6 +82,7 @@ img {
 
 .has-dropdown:focus-within .dropdown   {
     opacity: 1;
+    z-index: 1;
     pointer-events: auto;
 }
 


### PR DESCRIPTION
In this version of css theme toggler app I've resolved these problems: 

* Initial ```light``` class is now being added to the body **programmatically**. In the _Fireship's_ version after page reload you could notice that body deriving preffered theme from the local storage and adding it to the already exsisiting one which is **hardcoded** light theme (so, if preferred theme was **dark** then after the page reload you will see ```<body class="light dark">```.
* In initial version of this app if you choose **solarized** theme — ```solarizeButton``` acquires _normalize_ ```innerText``` property. But when page is reloaded it **loses** its value although the theme is still **solarized**. Now it will keep it.
* Dropdown was accessible via page inspector and **dev tools** even when it was hidden. I've changed its ```z-index``` property so now it is truly **unreachable** when hidden.
* Removed unnecessary ```pointer-events: auto;``` property because its **implicitly** has necessary value.